### PR TITLE
Fixed small typo

### DIFF
--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -837,7 +837,7 @@ Mixins can happen at any time of your object's life.
     put $toc-counter / 1;          # NaN (because that's numerical context)
     put $toc-counter;              # 2.2.2 (put will call TOC-Counter::Str)
 
-Roles can by anonymous.
+Roles can be anonymous.
 
     my %seen of Int is default(0 but role :: { method Str() {'NULL'} });
     say %seen<not-there>;          # NULL


### PR DESCRIPTION
"Roles can by anonymous" -> "Roles can be anonymous"
